### PR TITLE
Update for Version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,7 +1,24 @@
 [[package]]
-name = "aurebuildcheck-rs"
-version = "0.1.0"
+name = "ansi_term"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "atty"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aurebuildcheck-rs"
+version = "0.2.0"
+dependencies = [
+ "clap 2.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -9,6 +26,20 @@ dependencies = [
 name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "coco"
@@ -36,6 +67,11 @@ dependencies = [
 [[package]]
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "json"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -87,20 +123,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
+"checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
+"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum clap 2.29.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b8f59bcebcfe4269b09f71dab0da15b355c75916a8f975d3876ce81561893ee"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9ad0485404155f45cce53a40d4b2d6ac356418300daed05273d9e26f91c390be"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
 "checksum rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b609139d83da75902f88fd6c01820046840a18471e4dfcd5ac7c0f46bea53"
+"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ json = "0.11.13"
 [profile.release]
 lto = true
 panic = 'abort'
+codegen-units=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,21 @@
 [package]
 name = "aurebuildcheck-rs"
-version = "0.1.0"
-authors = ["Matthias Krüger <matthias.krueger@famsik.de>"]
+version = "0.2.0"
+authors = [
+    "Matthias Krüger <matthias.krueger@famsik.de>",
+    "Marc Mettke <marc@itmettke.de>"
+]
+repository = "https://github.com/matthiaskrgr/aurebuildcheck-rs"
+homepage = "https://github.com/matthiaskrgr/aurebuildcheck-rs"
+license = "MIT"
+readme = "README.md"
+description = "Archlinux package checker to identify packages which may need a rebuild"
 
 [dependencies]
-rayon = "0.9" # parallelize
+rayon = "0.9.0"
+clap = "2.29.4"
+json = "0.11.13"
+
+[profile.release]
+lto = true
+panic = 'abort'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Marc Mettke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# aurebuildcheck-rs
+
+aurebuildcheck

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-cargo rustc --release
+cargo build --release
 # Stripping removes a lot of debug symbols and therefore
 # decreases the binary size. Unfortunately it also removes
 # the ability to use panic

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cargo rustc --release
+# Stripping removes a lot of debug symbols and therefore
+# decreases the binary size. Unfortunately it also removes
+# the ability to use panic
+strip target/release/aurebuildcheck-rs

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+reorder_imports = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,13 @@ pub enum Command {
     Readelf,
 }
 
+// Specifies the various ways to output the missing library information
+#[derive(Debug)]
+pub enum Output {
+    Console,
+    JSON,
+}
+
 /// These Settings define how the program operates and are used everywhere
 #[derive(Debug)]
 pub struct CommandLineSettings {
@@ -15,7 +22,7 @@ pub struct CommandLineSettings {
     pub all_packages: bool,
     pub ignore_libraries: Vec<String>,
     pub show_candidates: bool,
-    pub output_json: bool,
+    pub output: Output,
     pub quite: bool,
     pub group_by_file: bool,
     pub group_by_library: bool,
@@ -30,7 +37,7 @@ impl Default for CommandLineSettings {
             all_packages: false,
             ignore_libraries: vec![],
             show_candidates: false,
-            output_json: false,
+            output: Output::Console,
             quite: false,
             group_by_file: false,
             group_by_library: false,
@@ -56,7 +63,7 @@ pub fn get_command_line_settings() -> CommandLineSettings {
         settings.show_candidates = true;
     }
     if parser.is_present("output json") {
-        settings.output_json = true;
+        settings.output = Output::JSON;
     }
     if parser.is_present("quite") {
         settings.quite = true;
@@ -84,7 +91,7 @@ pub fn get_command_line_settings() -> CommandLineSettings {
     settings
 }
 
-fn get_subcommand_line_settings<'a>(parser: &ArgMatches<'a>, settings: &mut CommandLineSettings) {
+fn get_subcommand_line_settings(parser: &ArgMatches, settings: &mut CommandLineSettings) {
     if let Some(packages) = parser.values_of_lossy("packages") {
         settings.packages = packages;
     }
@@ -180,6 +187,7 @@ Requires pkgfile",
                 .help("Uses json for the list of missing libraries"),
         )
         .arg(
+            // TODO: Replace with verbose
             Arg::with_name("quite")
                 .short("q")
                 .long("quite")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,206 @@
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+
+/// Specifies the various ways to check elf files for missing libraries
+#[derive(Debug)]
+pub enum Command {
+    Ldd,
+    Readelf,
+}
+
+/// These Settings define how the program operates and are used everywhere
+#[derive(Debug)]
+pub struct CommandLineSettings {
+    pub command: Command,
+    pub packages: Vec<String>,
+    pub all_packages: bool,
+    pub ignore_libraries: Vec<String>,
+    pub show_candidates: bool,
+    pub output_json: bool,
+    pub quite: bool,
+    pub group_by_file: bool,
+    pub group_by_library: bool,
+    pub group_by_containing_package: bool,
+}
+
+impl Default for CommandLineSettings {
+    fn default() -> Self {
+        CommandLineSettings {
+            command: Command::Ldd,
+            packages: vec![],
+            all_packages: false,
+            ignore_libraries: vec![],
+            show_candidates: false,
+            output_json: false,
+            quite: false,
+            group_by_file: false,
+            group_by_library: false,
+            group_by_containing_package: false,
+        }
+    }
+}
+
+pub fn get_command_line_settings() -> CommandLineSettings {
+    let mut settings = CommandLineSettings::default();
+    let parser = setup_command_line_parser();
+
+    if let Some(subcommand) = parser.subcommand_matches("ldd") {
+        settings.command = Command::Ldd;
+        get_subcommand_line_settings(subcommand, &mut settings);
+    }
+    if let Some(subcommand) = parser.subcommand_matches("readelf") {
+        settings.command = Command::Readelf;
+        get_subcommand_line_settings(subcommand, &mut settings);
+    }
+
+    if parser.is_present("show candidates") {
+        settings.show_candidates = true;
+    }
+    if parser.is_present("output json") {
+        settings.output_json = true;
+    }
+    if parser.is_present("quite") {
+        settings.quite = true;
+    }
+    if parser.is_present("group by file") {
+        settings.group_by_file = true;
+    }
+    if parser.is_present("group by library") {
+        settings.group_by_library = true;
+    }
+    if parser.is_present("group by containing package") {
+        settings.group_by_containing_package = true;
+    }
+
+    // by default (if not specified otherwise) only files
+    // and libraries are printed. Packages are printed only
+    // if specified or by default if `show_candidates` is set
+    if !settings.group_by_file && !settings.group_by_library
+        && !settings.group_by_containing_package
+    {
+        settings.group_by_file = true;
+        settings.group_by_library = true;
+        settings.group_by_containing_package = settings.show_candidates;
+    }
+    settings
+}
+
+fn get_subcommand_line_settings<'a>(parser: &ArgMatches<'a>, settings: &mut CommandLineSettings) {
+    if let Some(packages) = parser.values_of_lossy("packages") {
+        settings.packages = packages;
+    }
+    if parser.is_present("all packages") {
+        settings.all_packages = true;
+    }
+    if let Some(ignore_libraries) = parser.values_of_lossy("ignore libraries") {
+        settings.ignore_libraries = ignore_libraries;
+    }
+}
+
+fn setup_command_line_parser<'a>() -> ArgMatches<'a> {
+    App::new(crate_name!())
+        .version(crate_version!())
+        .author(crate_authors!(", "))
+        .about(crate_description!())
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(
+            SubCommand::with_name("ldd")
+                .about("Checks packages using ldd")
+                .arg(
+                    Arg::with_name("packages")
+                        .multiple(true)
+                        .use_delimiter(true)
+                        .number_of_values(1)
+                        .help("List of packages to check (eg package1,package2)")
+                        .required_unless("all_packages")
+                        .conflicts_with("all_packages"),
+                )
+                .arg(
+                    Arg::with_name("all packages")
+                        .short("a")
+                        .long("all_packages")
+                        .help("Checks all installed packages marked as local")
+                        .conflicts_with("packages"),
+                )
+                .arg(
+                    Arg::with_name("ignore libraries")
+                        .short("i")
+                        .long("ignore_libs")
+                        .multiple(true)
+                        .use_delimiter(true)
+                        .number_of_values(1)
+                        .help("List of libraries to ignore (eg lib1,lib2)"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("readelf")
+                .about("Checks packages using readelf")
+                .arg(
+                    Arg::with_name("packages")
+                        .multiple(true)
+                        .use_delimiter(true)
+                        .number_of_values(1)
+                        .help("List of packages to check (eg package1,package2)")
+                        .required_unless("all_packages")
+                        .conflicts_with("all_packages"),
+                )
+                .arg(
+                    Arg::with_name("all packages")
+                        .short("a")
+                        .long("all_packages")
+                        .help("Checks all installed packages marked as local")
+                        .conflicts_with("packages"),
+                )
+                .arg(
+                    Arg::with_name("ignore libraries")
+                        .short("i")
+                        .long("ignore_libs")
+                        .multiple(true)
+                        .use_delimiter(true)
+                        .number_of_values(1)
+                        .help("List of libraries to ignore (eg lib1,lib2)"),
+                ),
+        )
+        .arg(
+            Arg::with_name("show candidates")
+                .short("c")
+                .long("show_candidates")
+                .help("Prints a list of packages containing the missing library")
+                .long_help(
+                    "Prints a list of packages containing the missing library. 
+The listed packages may or may not add the library to the 
+system path. Therefore just because a package is listed 
+doesn't mean it will satisfy the library requirement. 
+Requires pkgfile",
+                ),
+        )
+        .arg(
+            Arg::with_name("output json")
+                .short("j")
+                .long("output_json")
+                .help("Uses json for the list of missing libraries"),
+        )
+        .arg(
+            Arg::with_name("quite")
+                .short("q")
+                .long("quite")
+                .visible_alias("s")
+                .visible_alias("silent")
+                .help("Hides all messages"),
+        )
+        .arg(
+            Arg::with_name("group by file")
+                .long("group_by_file")
+                .help("groups output by files missing libraries"),
+        )
+        .arg(
+            Arg::with_name("group by library")
+                .long("group_by_library")
+                .help("groups output by librarires required in files"),
+        )
+        .arg(
+            Arg::with_name("group by containing package")
+                .long("group_by_containing_package")
+                .help("groups output by packages containg libraries"),
+        )
+        .get_matches()
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -203,12 +203,12 @@ Requires pkgfile",
         .arg(
             Arg::with_name("group by library")
                 .long("group_by_library")
-                .help("groups output by librarires required in files"),
+                .help("groups output by libraries required in files"),
         )
         .arg(
             Arg::with_name("group by containing package")
                 .long("group_by_containing_package")
-                .help("groups output by packages containg libraries"),
+                .help("groups output by packages containing libraries"),
         )
         .get_matches()
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -66,27 +66,27 @@ pub fn verify_files_via_ldd<'a>(file: &str) -> Result<Option<FileDependency>, Er
     // TODO: ldd prints warnings - should be included in verbose output
     let output = String::from_utf8_lossy(&out.stdout);
     for line in output.lines() {
-        if line.ends_with("=> not found") {
+        if line.ends_with(" => not found") {
             let mut library_name = String::from(line.trim());
-            let new_length = library_name.len() - 13;
+            let new_length = library_name.len() - " => not found".len();
             library_name.truncate(new_length);
             dependency.library_dependencies.insert(library_name);
         }
     }
-    if dependency.library_dependencies.len() > 0 {
-        Ok(Some(dependency))
-    } else {
+    if dependency.library_dependencies.is_empty() {
         Ok(None)
+    } else {
+        Ok(Some(dependency))        
     }
 }
 
 pub fn verify_files_via_readelf<'a>(file: &str) -> Result<Option<FileDependency>, Error<'a>> {
     let mut dependency = FileDependency::default();
     dependency.file_name = String::from(file);
-    if dependency.library_dependencies.len() > 0 {
-        Ok(Some(dependency))
-    } else {
+    if dependency.library_dependencies.is_empty() {
         Ok(None)
+    } else {
+        Ok(Some(dependency))        
     }
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,0 +1,123 @@
+use cli;
+use data::{Error, FileDependency, Package};
+use std::process::Command;
+
+pub fn check_required_programs(settings: &cli::CommandLineSettings) -> Result<(), Error> {
+    match check_required_program("pacman") {
+        Err(_) => return Err(Error::Dependency("pacman")),
+        _ => {}
+    }
+    match check_required_program("file") {
+        Err(_) => return Err(Error::Dependency("file")),
+        _ => {}
+    }
+    match &settings.command {
+        &cli::Command::Ldd => match check_required_program("ldd") {
+            Err(_) => return Err(Error::Dependency("ldd")),
+            _ => {}
+        },
+        &cli::Command::Readelf => match check_required_program("readelf") {
+            Err(_) => return Err(Error::Dependency("readelf")),
+            _ => {}
+        },
+    }
+    if settings.show_candidates {
+        match check_required_program("pkgfile") {
+            Err(_) => return Err(Error::Dependency("pkgfile")),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn check_required_program(program: &str) -> Result<(), ()> {
+    match Command::new("which").arg(program).output() {
+        Err(_) => Err(()),
+        _ => Ok(()),
+    }
+}
+
+pub fn get_all_packages(settings: &mut cli::CommandLineSettings) -> Result<(), Error> {
+    let out = Command::new("pacman").arg("-Qqm").output()?;
+    let output = String::from_utf8_lossy(&out.stdout);
+    let output = output.into_owned();
+    for package in output.lines() {
+        settings.packages.push(package.into());
+    }
+    Ok(())
+}
+
+pub fn get_files_for_package<'a>(package: &Package) -> Result<Vec<String>, Error<'a>> {
+    let mut files = Vec::new();
+    let out = Command::new("pacman")
+        .arg("-Qql")
+        .arg(&package.name)
+        .output()?;
+    let output = String::from_utf8_lossy(&out.stdout);
+    let output = output.into_owned();
+    for package in output.lines() {
+        files.push(package.into());
+    }
+    Ok(files)
+}
+
+pub fn file_is_elf<'a>(file: &str) -> Result<bool, Error<'a>> {
+    let out = Command::new("file").arg(&file).output()?;
+    let output = String::from_utf8_lossy(&out.stdout);
+    Ok(output.contains("ELF"))
+}
+
+pub fn verify_files_via_ldd<'a>(
+    file: &str,
+    settings: &cli::CommandLineSettings,
+    filenames: &Vec<String>,
+) -> Result<Option<FileDependency>, Error<'a>> {
+    let mut dependency = FileDependency::default();
+    dependency.file_name = String::from(file);
+    let out = Command::new("ldd").arg(&file).output()?;
+    let output = String::from_utf8_lossy(&out.stdout);
+    for line in output.lines() {
+        if line.ends_with("=> not found") {
+            let library_name = String::from(line.replace("=> not found", "").trim());
+            // only add if library is not in ignore
+            if !settings.ignore_libraries.contains(&library_name)
+                // library is not in package file
+                && !filenames.contains(&library_name)
+                // and was not already found
+                && !dependency.library_dependencies.contains(&library_name)
+            {
+                dependency.library_dependencies.push(library_name);
+            }
+        }
+    }
+    if dependency.library_dependencies.len() > 0 {
+        Ok(Some(dependency))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn verify_files_via_readelf<'a>(
+    file: &str,
+    _settings: &cli::CommandLineSettings,
+    _filenames: &Vec<String>,
+) -> Result<Option<FileDependency>, Error<'a>> {
+    let mut dependency = FileDependency::default();
+    dependency.file_name = String::from(file);
+    if dependency.library_dependencies.len() > 0 {
+        Ok(Some(dependency))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn get_packages_containing_library<'a>(library: &str) -> Result<Vec<String>, Error<'a>> {
+    let mut packages = Vec::new();
+    let out = Command::new("pkgfile").arg(&library).output()?;
+    let output = String::from_utf8_lossy(&out.stdout);
+    let output = output.into_owned();
+    for package in output.lines() {
+        packages.push(package.into());
+    }
+    Ok(packages)
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,10 +1,12 @@
 use std::{error, fmt, io};
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
 #[derive(Debug)]
 pub enum Error<'a> {
     Dependency(&'a str),
     Execution(io::Error),
+    ExecutionError(String),
 }
 
 impl<'a> fmt::Display for Error<'a> {
@@ -12,6 +14,7 @@ impl<'a> fmt::Display for Error<'a> {
         match *self {
             Error::Dependency(ref dep) => write!(f, "Dependency missing: {}", dep),
             Error::Execution(ref err) => write!(f, "Command execution error: {}", err),
+            Error::ExecutionError(ref err) => write!(f, "Command execution error: {:#?}", err),
         }
     }
 }
@@ -23,6 +26,7 @@ impl<'a> error::Error for Error<'a> {
                 "Dependency is missing and must be installed before running this command"
             }
             Error::Execution(ref err) => err.description(),
+            Error::ExecutionError(_) => "Execution of program failed with non zero",
         }
     }
 
@@ -30,6 +34,7 @@ impl<'a> error::Error for Error<'a> {
         match *self {
             Error::Dependency(_) => None,
             Error::Execution(ref err) => Some(err),
+            Error::ExecutionError(_) => None,
         }
     }
 }
@@ -85,7 +90,7 @@ impl PartialEq for Package {
 #[derive(Debug, Default)]
 pub struct FileDependency {
     pub file_name: String,
-    pub library_dependencies: Vec<String>,
+    pub library_dependencies: HashSet<String>,
 }
 
 #[derive(Debug, Default)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,101 @@
+use std::{error, fmt, io};
+use std::cmp::Ordering;
+
+#[derive(Debug)]
+pub enum Error<'a> {
+    Dependency(&'a str),
+    Execution(io::Error),
+}
+
+impl<'a> fmt::Display for Error<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Dependency(ref dep) => write!(f, "Dependency missing: {}", dep),
+            Error::Execution(ref err) => write!(f, "Command execution error: {}", err),
+        }
+    }
+}
+
+impl<'a> error::Error for Error<'a> {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Dependency(_) => {
+                "Dependency is missing and must be installed before running this command"
+            }
+            Error::Execution(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::Dependency(_) => None,
+            Error::Execution(ref err) => Some(err),
+        }
+    }
+}
+
+impl<'a> From<io::Error> for Error<'a> {
+    fn from(err: io::Error) -> Self {
+        Error::Execution(err)
+    }
+}
+
+#[derive(Debug)]
+pub struct Package {
+    pub name: String,
+    //#[serde(skip_serializing_if = "path")]
+    pub file_dependencies: Vec<FileDependency>,
+    //#[serde(skip_serializing_if = "path")]
+    pub library_requirements: Vec<LibraryRequired>,
+    // #[serde(skip_serializing_if = "path")]
+    pub packages_containing: Vec<PackagesContaining>,
+}
+
+impl Package {
+    pub fn new<S: Into<String>>(name: S) -> Self {
+        Package {
+            name: name.into(),
+            file_dependencies: vec![],
+            library_requirements: vec![],
+            packages_containing: vec![],
+        }
+    }
+}
+
+impl Ord for Package {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl PartialOrd for Package {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for Package {}
+
+impl PartialEq for Package {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FileDependency {
+    pub file_name: String,
+    pub library_dependencies: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct LibraryRequired {
+    pub library_name: String,
+    pub files_requiring: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct PackagesContaining {
+    pub library_name: String,
+    pub packages_containing: Vec<String>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn check_binary(filename: &str) {
 
 fn get_packages() -> Vec<String> {
     let mut packages = Vec::new();
-    match Command::new("rpm").arg("-q").arg("-a").output() {
+    match Command::new("pacman").arg("-Qqm").output() {
         Ok(out) => {
             let output = String::from_utf8_lossy(&out.stdout);
             let output = output.into_owned();
@@ -62,9 +62,8 @@ fn get_packages() -> Vec<String> {
 
 fn get_files(package: &str) -> Vec<String> {
     let mut files = Vec::new();
-    match Command::new("rpm")
-        .arg("-q")
-        .arg("-l")
+    match Command::new("pacman")
+        .arg("-Qql")
         .arg(&package)
         .output()
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 //! A program for checking ArchLinux packages for missing libraries.
 //!
-//! If a package is missing a library it may means, that is necessary to rebuild that given package.
+//! If a package is missing a library it may mean, that is necessary to rebuild that given package.
 //! This binary checks every elf file in a package using either ldd or readelf and reports missing
 //! libraries.
 
@@ -36,7 +36,7 @@ use std::process::exit;
 
 fn main() {
     let mut settings = cli::get_command_line_settings();
-    handle_error(cmd::check_required_programs(&settings), 1);
+    handle_error(cmd::check_required_programs(&settings), 2);
 
     // TODO: Implement readelf and remove following lines
     match settings.command {
@@ -48,7 +48,7 @@ fn main() {
     }
 
     if settings.all_packages {
-        handle_error(cmd::get_all_packages(&mut settings), 2);
+        handle_error(cmd::get_all_packages(&mut settings), 3);
     }
     // TODO: Replace with verbose
     // TODO: Print more information with verbose like the file types which are checked
@@ -72,9 +72,14 @@ fn main() {
         println!("");
     }
 
-    let packages = handle_error(process::verify_packages(&settings), 3);
+    let packages = handle_error(process::verify_packages(&settings), 4);
     output::print_packages(&packages, &settings);
-    exit(0);
+    match packages.iter().any(|package| {
+        !package.file_dependencies.is_empty()
+    }) {
+        true => exit(1),
+        false => exit(0)
+    }
 }
 
 /// Error Handling for the main method. Takes a result and either

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,28 @@ fn main() {
     if settings.all_packages {
         handle_error(cmd::get_all_packages(&mut settings), 2);
     }
+    // TODO: Replace with verbose
+    // TODO: Print more information with verbose like the file types which are checked
+    if !settings.quite {
+        print!("Checking Packages: ");
+        for (index, package) in settings.packages.iter().enumerate() {
+            if index != 0 {
+                print!(", ");
+            }
+            print!("{}", package);
+        }
+        println!("");
+
+        print!("Ignoring Libraries: ");
+        for (index, package) in settings.ignore_libraries.iter().enumerate() {
+            if index != 0 {
+                print!(", ");
+            }
+            print!("{}", package);
+        }
+        println!("");
+    }
+
     let packages = handle_error(process::verify_packages(&settings), 3);
     output::print_packages(&packages, &settings);
     exit(0);

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,120 @@
+use cli::CommandLineSettings;
+use data::Package;
+use json;
+
+pub fn print_packages(packages: &Vec<Package>, settings: &CommandLineSettings) {
+    if settings.output_json {
+        print_json(packages, settings);
+    } else {
+        print_console(packages, settings);
+    }
+}
+
+fn print_console(packages: &Vec<Package>, settings: &CommandLineSettings) {
+    for (i, package) in packages.iter().enumerate() {
+        if i != 0 {
+            println!("");
+        }
+        println!("========================================");
+        println!("Package: {}", package.name);
+        println!("========================================");
+        if settings.group_by_file {
+            package.file_dependencies.iter().for_each(|dependency| {
+                println!("\nelf file \"{}\" is missing:", dependency.file_name);
+                dependency.library_dependencies.iter().for_each(|library| {
+                    println!("\t{}", library);
+                })
+            });
+        }
+        if settings.group_by_library {
+            package.library_requirements.iter().for_each(|library| {
+                println!("\nlibrary \"{}\" is required by:", library.library_name);
+                library.files_requiring.iter().for_each(|file| {
+                    println!("\t{}", file);
+                })
+            });
+        }
+        if settings.group_by_containing_package {
+            package
+                .packages_containing
+                .iter()
+                .for_each(|package_entry| {
+                    println!(
+                        "\nlibrary \"{}\" is packaged in:",
+                        package_entry.library_name
+                    );
+                    package_entry
+                        .packages_containing
+                        .iter()
+                        .for_each(|package| {
+                            println!("\t{}", package);
+                        })
+                });
+        }
+    }
+}
+
+fn print_json(packages: &Vec<Package>, settings: &CommandLineSettings) {
+    let mut json_packages = json::JsonValue::new_array();
+    for package in packages.iter() {
+        let mut json_package = json::JsonValue::new_object();
+        json_package["package_name"] = package.name.clone().into();
+        if settings.group_by_file {
+            let mut json_file_dependencies = json::JsonValue::new_array();
+            package.file_dependencies.iter().for_each(|dependency| {
+                let mut json_file_dependency = json::JsonValue::new_object();
+                json_file_dependency["file_name"] = dependency.file_name.clone().into();
+                let mut json_file_dependencies_array = json::JsonValue::new_array();
+                dependency.library_dependencies.iter().for_each(|library| {
+                    json_file_dependencies_array.push(library.clone()).unwrap();
+                });
+                json_file_dependency["library_dependencies"] = json_file_dependencies_array;
+                json_file_dependencies.push(json_file_dependency).unwrap();
+            });
+            json_package["file_dependencies"] = json_file_dependencies;
+        }
+        if settings.group_by_library {
+            let mut json_library_requirements = json::JsonValue::new_array();
+            package.library_requirements.iter().for_each(|library| {
+                let mut json_library_requirement = json::JsonValue::new_object();
+                json_library_requirement["library_name"] = library.library_name.clone().into();
+                let mut json_library_requirements_array = json::JsonValue::new_array();
+                library.files_requiring.iter().for_each(|file| {
+                    json_library_requirements_array.push(file.clone()).unwrap();
+                });
+                json_library_requirement["files_requiring"] = json_library_requirements_array;
+                json_library_requirements
+                    .push(json_library_requirement)
+                    .unwrap();
+            });
+            json_package["library_requirements"] = json_library_requirements;
+        }
+        if settings.group_by_containing_package {
+            let mut json_packages_containing = json::JsonValue::new_array();
+            package
+                .packages_containing
+                .iter()
+                .for_each(|package_entry| {
+                    let mut json_package_containing = json::JsonValue::new_object();
+                    json_package_containing["library_name"] =
+                        package_entry.library_name.clone().into();
+                    let mut json_packages_containing_array = json::JsonValue::new_array();
+                    package_entry
+                        .packages_containing
+                        .iter()
+                        .for_each(|package| {
+                            json_packages_containing_array
+                                .push(package.clone())
+                                .unwrap();
+                        });
+                    json_package_containing["packages_containing"] = json_packages_containing_array;
+                    json_packages_containing
+                        .push(json_package_containing)
+                        .unwrap();
+                });
+            json_package["packages_containing"] = json_packages_containing;
+        }
+        json_packages.push(json_package).unwrap();
+    }
+    println!("{}", json_packages.dump());
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,12 +1,11 @@
-use cli::CommandLineSettings;
+use cli::{CommandLineSettings, Output};
 use data::Package;
 use json;
 
 pub fn print_packages(packages: &Vec<Package>, settings: &CommandLineSettings) {
-    if settings.output_json {
-        print_json(packages, settings);
-    } else {
-        print_console(packages, settings);
+    match settings.output {
+        Output::Console => print_console(packages, settings),
+        Output::JSON => print_json(packages, settings),
     }
 }
 
@@ -60,61 +59,72 @@ fn print_json(packages: &Vec<Package>, settings: &CommandLineSettings) {
         let mut json_package = json::JsonValue::new_object();
         json_package["package_name"] = package.name.clone().into();
         if settings.group_by_file {
-            let mut json_file_dependencies = json::JsonValue::new_array();
-            package.file_dependencies.iter().for_each(|dependency| {
-                let mut json_file_dependency = json::JsonValue::new_object();
-                json_file_dependency["file_name"] = dependency.file_name.clone().into();
-                let mut json_file_dependencies_array = json::JsonValue::new_array();
-                dependency.library_dependencies.iter().for_each(|library| {
-                    json_file_dependencies_array.push(library.clone()).unwrap();
-                });
-                json_file_dependency["library_dependencies"] = json_file_dependencies_array;
-                json_file_dependencies.push(json_file_dependency).unwrap();
-            });
-            json_package["file_dependencies"] = json_file_dependencies;
+            json_package["file_dependencies"] = print_json_file_dependencies(package);
         }
         if settings.group_by_library {
-            let mut json_library_requirements = json::JsonValue::new_array();
-            package.library_requirements.iter().for_each(|library| {
-                let mut json_library_requirement = json::JsonValue::new_object();
-                json_library_requirement["library_name"] = library.library_name.clone().into();
-                let mut json_library_requirements_array = json::JsonValue::new_array();
-                library.files_requiring.iter().for_each(|file| {
-                    json_library_requirements_array.push(file.clone()).unwrap();
-                });
-                json_library_requirement["files_requiring"] = json_library_requirements_array;
-                json_library_requirements
-                    .push(json_library_requirement)
-                    .unwrap();
-            });
-            json_package["library_requirements"] = json_library_requirements;
+            json_package["library_requirements"] = print_json_library_requirements(package);
         }
         if settings.group_by_containing_package {
-            let mut json_packages_containing = json::JsonValue::new_array();
-            package
-                .packages_containing
-                .iter()
-                .for_each(|package_entry| {
-                    let mut json_package_containing = json::JsonValue::new_object();
-                    json_package_containing["library_name"] =
-                        package_entry.library_name.clone().into();
-                    let mut json_packages_containing_array = json::JsonValue::new_array();
-                    package_entry
-                        .packages_containing
-                        .iter()
-                        .for_each(|package| {
-                            json_packages_containing_array
-                                .push(package.clone())
-                                .unwrap();
-                        });
-                    json_package_containing["packages_containing"] = json_packages_containing_array;
-                    json_packages_containing
-                        .push(json_package_containing)
-                        .unwrap();
-                });
-            json_package["packages_containing"] = json_packages_containing;
+            json_package["packages_containing"] = print_json_packages_containing(package);
         }
         json_packages.push(json_package).unwrap();
     }
     println!("{}", json_packages.dump());
+}
+
+fn print_json_file_dependencies(package: &Package) -> json::JsonValue {
+    let mut json_file_dependencies = json::JsonValue::new_array();
+    package.file_dependencies.iter().for_each(|dependency| {
+        let mut json_file_dependency = json::JsonValue::new_object();
+        json_file_dependency["file_name"] = dependency.file_name.clone().into();
+        let mut json_file_dependencies_array = json::JsonValue::new_array();
+        dependency.library_dependencies.iter().for_each(|library| {
+            json_file_dependencies_array.push(library.clone()).unwrap();
+        });
+        json_file_dependency["library_dependencies"] = json_file_dependencies_array;
+        json_file_dependencies.push(json_file_dependency).unwrap();
+    });
+    json_file_dependencies
+}
+
+fn print_json_library_requirements(package: &Package) -> json::JsonValue {
+    let mut json_library_requirements = json::JsonValue::new_array();
+    package.library_requirements.iter().for_each(|library| {
+        let mut json_library_requirement = json::JsonValue::new_object();
+        json_library_requirement["library_name"] = library.library_name.clone().into();
+        let mut json_library_requirements_array = json::JsonValue::new_array();
+        library.files_requiring.iter().for_each(|file| {
+            json_library_requirements_array.push(file.clone()).unwrap();
+        });
+        json_library_requirement["files_requiring"] = json_library_requirements_array;
+        json_library_requirements
+            .push(json_library_requirement)
+            .unwrap();
+    });
+    json_library_requirements
+}
+
+fn print_json_packages_containing(package: &Package) -> json::JsonValue {
+    let mut json_packages_containing = json::JsonValue::new_array();
+    package
+        .packages_containing
+        .iter()
+        .for_each(|package_entry| {
+            let mut json_package_containing = json::JsonValue::new_object();
+            json_package_containing["library_name"] = package_entry.library_name.clone().into();
+            let mut json_packages_containing_array = json::JsonValue::new_array();
+            package_entry
+                .packages_containing
+                .iter()
+                .for_each(|package| {
+                    json_packages_containing_array
+                        .push(package.clone())
+                        .unwrap();
+                });
+            json_package_containing["packages_containing"] = json_packages_containing_array;
+            json_packages_containing
+                .push(json_package_containing)
+                .unwrap();
+        });
+    json_packages_containing
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,140 @@
+use cli::{Command, CommandLineSettings};
+use cmd;
+use data::{Error, FileDependency, LibraryRequired, Package, PackagesContaining};
+use rayon::prelude::*;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+pub fn verify_packages<'a>(settings: &CommandLineSettings) -> Result<Vec<Package>, Error> {
+    let mut packages = settings
+        .packages
+        .iter()
+        .map(|package| Package::new(package.clone()))
+        .collect::<Vec<Package>>();
+    packages.sort();
+
+    packages
+        .par_iter_mut()
+        .map(|package| verify_package(package, settings))
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    Ok(packages)
+}
+
+fn verify_package<'a>(
+    package: &mut Package,
+    settings: &CommandLineSettings,
+) -> Result<(), Error<'a>> {
+    let files = cmd::get_files_for_package(package)?;
+    let filenames = get_filenames_from_files(&files);
+
+    package.file_dependencies = files
+        .par_iter()
+        // verify files parallel - will stop if error occures
+        .map(|file| verify_file(file, settings, &filenames))
+        // collect and abort if error
+        .collect::<Result<Vec<Option<FileDependency>>, Error>>()?
+        .into_iter()
+        // remove Option
+        .filter_map(|element| element)
+        .collect::<Vec<FileDependency>>();
+
+    setup_library_requirements(package)?;
+    if settings.show_candidates {
+        setup_packages_containing(package)?;
+    }
+    Ok(())
+}
+
+fn get_filenames_from_files(files: &Vec<String>) -> Vec<String> {
+    files
+        .iter()
+        .filter_map(|file| {
+            if let Some(path) = PathBuf::from(file).file_name() {
+                if let Some(filename) = path.to_str() {
+                    return Some(String::from(filename));
+                }
+            }
+            None
+        })
+        .collect::<Vec<String>>()
+}
+
+fn verify_file<'a>(
+    file: &str,
+    settings: &CommandLineSettings,
+    filenames: &Vec<String>,
+) -> Result<Option<FileDependency>, Error<'a>> {
+    if file_might_be_binary(file) && cmd::file_is_elf(file)? {
+        let dependency = match settings.command {
+            Command::Ldd => cmd::verify_files_via_ldd(file, settings, &filenames),
+            Command::Readelf => cmd::verify_files_via_readelf(file, settings, &filenames),
+        }?;
+        return Ok(dependency);
+    }
+    Ok(None)
+}
+
+fn file_might_be_binary(file: &str) -> bool {
+    let path = PathBuf::from(file);
+    if !path.is_file() {
+        return false;
+    }
+    if let Some(extension) = path.extension() {
+        if let Some(ext) = extension.to_str() {
+            return match ext {
+                "a" | "png" | "la" | "ttf" | "gz" | "html" | "css" | "h" | "c" | "cxx" | "xml"
+                | "rgb" | "gif" | "wav" | "ogg" | "ogv" | "avi" | "opus" | "mp3" | "po" | "txt"
+                | "jpg" | "jpeg" | "bmp" | "xcf" | "mo" | "rb" | "py" | "lua" | "config"
+                | "cfg" | "svg" | "desktop" | "conf" | "pdf" | "xz" => false,
+                "so" | _ => true,
+            };
+        }
+    }
+    true
+}
+
+fn setup_library_requirements<'a>(package: &mut Package) -> Result<(), Error<'a>> {
+    let mut cache: HashMap<String, LibraryRequired> = HashMap::new();
+    package
+        .file_dependencies
+        .iter()
+        .for_each(|file_dependency| {
+            file_dependency
+                .library_dependencies
+                .iter()
+                .for_each(|library_dependency| {
+                    if cache.contains_key(library_dependency) {
+                        if let Some(value) = cache.get_mut(library_dependency) {
+                            value
+                                .files_requiring
+                                .push(file_dependency.file_name.clone());
+                        }
+                    } else {
+                        cache.insert(
+                            library_dependency.clone(),
+                            LibraryRequired {
+                                library_name: library_dependency.clone(),
+                                files_requiring: vec![file_dependency.file_name.clone()],
+                            },
+                        );
+                    }
+                })
+        });
+    package.library_requirements = cache.into_iter().map(|(_, val)| val).collect();
+    Ok(())
+}
+
+fn setup_packages_containing<'a>(package: &mut Package) -> Result<(), Error<'a>> {
+    package.packages_containing = package
+        .library_requirements
+        .iter()
+        .map(|library| {
+            Ok(PackagesContaining {
+                library_name: library.library_name.clone(),
+                packages_containing: cmd::get_packages_containing_library(&library.library_name)?,
+            })
+        })
+        .collect::<Result<Vec<PackagesContaining>, Error>>()?;
+    Ok(())
+}


### PR DESCRIPTION
## Changes

* Added script for release builds and release profile
* Added json and clap dependency
* Added further package metadata
* Added license and empty readme
* Added format file
* Added cli parsing
* Added readelf stub
* Added checks for required programs
* Package verify is now ignoring libraries contained inside the package itself
* Added data structure to separate input, processing, and output
* Added json for output
* Added nested parallel execution to include fetching files for packages
* Listing libraries for files, files for libraries and packages for libraries
* Added ability to check only selected packages
* Added ability to ignore libraries

## Usage

```bash
$ aurebuildcheck-rs
aurebuildcheck-rs 0.2.0
Matthias Krüger <matthias.krueger@famsik.de>, Marc Mettke <marc@itmettke.de>
Archlinux package checker to identify packages which may need a rebuild

USAGE:
    aurebuildcheck-rs [FLAGS] <SUBCOMMAND>

FLAGS:
        --group_by_containing_package    groups output by packages containg libraries
        --group_by_file                  groups output by files missing libraries
        --group_by_library               groups output by librarires required in files
    -h, --help                           Prints help information
    -j, --output_json                    Uses json for the list of missing libraries
    -q, --quite                          Hides all messages [aliases: s, silent]
    -c, --show_candidates                Prints a list of packages containing the missing library
    -V, --version                        Prints version information

SUBCOMMANDS:
    help       Prints this message or the help of the given subcommand(s)
    ldd        Checks packages using ldd
    readelf    Checks packages using readelf
```

```bash
$ aurebuildcheck-rs ldd --help
aurebuildcheck-rs-ldd
Checks packages using ldd

USAGE:
    aurebuildcheck-rs ldd [FLAGS] [OPTIONS] <packages>...

FLAGS:
    -a, --all_packages    Checks all installed packages marked as local
    -h, --help            Prints help information
    -V, --version         Prints version information

OPTIONS:
    -i, --ignore_libs <ignore libraries>...    List of libraries to ignore (eg lib1,lib2)

ARGS:
    <packages>...    List of packages to check (eg package1,package2)
```

## Output

These results are rigged. Don't try to archive them yourself by running the binary, 'cause the missing libraries are included in the package itself and will be filtered out. I have removed that functionality for this output to be able to showcase something

```bash
$ aurebuildcheck-rs ldd android-studio
elf file "/opt/android-studio/jre/jre/lib/amd64/libattach.so" is missing:
        libjvm.so

(...)

library "libjvm.so" is required by:
        /opt/android-studio/jre/jre/lib/amd64/libattach.so
        /opt/android-studio/jre/jre/lib/amd64/libawt.so
        (...)
```

```bash
$ aurebuildcheck-rs -c ldd android-studio
elf file "/opt/android-studio/jre/jre/lib/amd64/libattach.so" is missing:
        libjvm.so

(...)

library "libjvm.so" is required by:
        /opt/android-studio/jre/jre/lib/amd64/libattach.so
        /opt/android-studio/jre/jre/lib/amd64/libawt.so
        (...)

library "libjvm.so" is packaged in:
        extra/jre7-openjdk-headless
        extra/jre8-openjdk-headless
        (...)
```

```bash
$ aurebuildcheck-rs -j ldd android-studio
[{"package_name":"android-studio","file_dependencies":[{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libattach.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libawt.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libawt_headless.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libawt_xawt.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libfontmanager.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libjava.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libjawt.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libjpeg.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/liblcms.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libmanagement.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libnet.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libnio.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libsctp.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libunpack.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libverify.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/jre/lib/amd64/libzip.so","library_dependencies":["libjvm.so"]},{"file_name":"/opt/android-studio/jre/lib/amd64/libjawt.so","library_dependencies":["libawt_xawt.so"]}],"library_requirements":[{"library_name":"libjvm.so","files_requiring":["/opt/android-studio/jre/jre/lib/amd64/libattach.so","/opt/android-studio/jre/jre/lib/amd64/libawt.so","/opt/android-studio/jre/jre/lib/amd64/libawt_headless.so","/opt/android-studio/jre/jre/lib/amd64/libawt_xawt.so","/opt/android-studio/jre/jre/lib/amd64/libfontmanager.so","/opt/android-studio/jre/jre/lib/amd64/libjava.so","/opt/android-studio/jre/jre/lib/amd64/libjawt.so","/opt/android-studio/jre/jre/lib/amd64/libjpeg.so","/opt/android-studio/jre/jre/lib/amd64/liblcms.so","/opt/android-studio/jre/jre/lib/amd64/libmanagement.so","/opt/android-studio/jre/jre/lib/amd64/libnet.so","/opt/android-studio/jre/jre/lib/amd64/libnio.so","/opt/android-studio/jre/jre/lib/amd64/libsctp.so","/opt/android-studio/jre/jre/lib/amd64/libunpack.so","/opt/android-studio/jre/jre/lib/amd64/libverify.so","/opt/android-studio/jre/jre/lib/amd64/libzip.so"]},{"library_name":"libawt_xawt.so","files_requiring":["/opt/android-studio/jre/lib/amd64/libjawt.so"]}]}]
```

## TODO

- [ ] Performance tests - was I able to completely ruin the performance with my changes?
- [ ] Execution of "all packages" - I'm currently not able to try to run on all packages
- [ ] Testing Error Handling
- [ ] Implement readelf
- [x] Exit Code (non 0) if libraries are missing

## Further changes

> Do you think it would make sense to be able to take enviromental LD_LIBRARY_PATH into account?

I will look into it a bit more when I implement readelf. But sounds reasonable to add it

> Would it make sense to ignore libraries on a larger scale via regex?
Something like --ignore "foo.so.*" or --ignore bar.so.3.*

That is a great idea. I will definitely take a look at regex crates for rust 